### PR TITLE
Admin promote/delete sensors, two-component (Dual) family, optional protein IDs

### DIFF
--- a/src/Components/About/Admin/v2/AdminProcessedSensorsV2.js
+++ b/src/Components/About/Admin/v2/AdminProcessedSensorsV2.js
@@ -4,19 +4,32 @@ import {
   Paper,
   Typography,
   Button,
-  Alert,
   Dialog,
   DialogContent,
   DialogTitle,
+  DialogActions,
   IconButton,
 } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import CloseIcon from '@mui/icons-material/Close';
+import { useSnackbar } from 'notistack';
 
 import SensorPageV2View from '../../../Sensor_Components/SensorPageV2View';
+import {
+  approveProcessedSensorV2,
+  rejectProcessedSensorV2,
+} from '../../../../lib/api/v2Admin';
 
-export default function AdminProcessedSensorsV2({ processed }) {
+export default function AdminProcessedSensorsV2({
+  processed,
+  user,
+  onPromoted,
+  onRejected,
+}) {
   const [viewing, setViewing] = useState(null);
+  const [actingUUID, setActingUUID] = useState(null);
+  const [confirm, setConfirm] = useState(null); // { action: 'promote'|'reject', row }
+  const { enqueueSnackbar } = useSnackbar();
 
   const rows = useMemo(() => {
     if (!processed) return [];
@@ -26,6 +39,7 @@ export default function AdminProcessedSensorsV2({ processed }) {
       return {
         id: idx,
         submissionUUID: p.submissionUUID,
+        category: p.category,
         type: p.data?.type ?? '—',
         aliases: aliases || '(no alias)',
         proteinCount: proteins.length,
@@ -34,6 +48,97 @@ export default function AdminProcessedSensorsV2({ processed }) {
       };
     });
   }, [processed]);
+
+  const doPromote = async (row) => {
+    setActingUUID(row.submissionUUID);
+    try {
+      const { status, body } = await approveProcessedSensorV2(
+        user,
+        row.category,
+        row.submissionUUID
+      );
+      switch (status) {
+        case 200:
+          enqueueSnackbar(
+            `Promoted ${row.aliases} → ${body.grv_id}`,
+            { variant: 'success', preventDuplicate: true }
+          );
+          onPromoted?.(row.submissionUUID);
+          break;
+        case 409:
+          enqueueSnackbar(
+            `Already promoted: ${row.aliases}`,
+            { variant: 'warning', preventDuplicate: true }
+          );
+          onPromoted?.(row.submissionUUID);
+          break;
+        case 404:
+          enqueueSnackbar(
+            `Not found: ${row.submissionUUID.slice(0, 8)}`,
+            { variant: 'error', preventDuplicate: true }
+          );
+          break;
+        case 400:
+          enqueueSnackbar(
+            `Invalid: ${body.message || 'bad input'}`,
+            { variant: 'error', preventDuplicate: true }
+          );
+          break;
+        default:
+          enqueueSnackbar(
+            `Error promoting: ${body.message || 'HTTP ' + status}`,
+            { variant: 'error', preventDuplicate: true }
+          );
+      }
+    } catch (err) {
+      enqueueSnackbar(`Network error: ${err.message}`, {
+        variant: 'error',
+        preventDuplicate: true,
+      });
+    } finally {
+      setActingUUID(null);
+      setConfirm(null);
+    }
+  };
+
+  const doReject = async (row) => {
+    setActingUUID(row.submissionUUID);
+    try {
+      const { status, body } = await rejectProcessedSensorV2(
+        user,
+        row.category,
+        row.submissionUUID
+      );
+      if (status === 204) {
+        enqueueSnackbar(
+          `Rejected ${row.aliases} (${row.submissionUUID.slice(0, 8)})`,
+          { variant: 'success', preventDuplicate: true }
+        );
+        onRejected?.(row.submissionUUID);
+      } else if (status === 404) {
+        enqueueSnackbar(
+          `Already gone: ${row.submissionUUID.slice(0, 8)}`,
+          { variant: 'info', preventDuplicate: true }
+        );
+        onRejected?.(row.submissionUUID);
+      } else {
+        enqueueSnackbar(
+          `Error rejecting ${row.submissionUUID.slice(0, 8)}: ${
+            body.message || `HTTP ${status}`
+          }`,
+          { variant: 'error', preventDuplicate: true }
+        );
+      }
+    } catch (err) {
+      enqueueSnackbar(`Network error: ${err.message}`, {
+        variant: 'error',
+        preventDuplicate: true,
+      });
+    } finally {
+      setActingUUID(null);
+      setConfirm(null);
+    }
+  };
 
   const columns = [
     { field: 'type', headerName: 'Type', width: 140 },
@@ -71,6 +176,40 @@ export default function AdminProcessedSensorsV2({ processed }) {
         </Button>
       ),
     },
+    {
+      field: 'promote',
+      headerName: 'Promote',
+      width: 120,
+      sortable: false,
+      renderCell: (params) => (
+        <Button
+          variant="contained"
+          color="success"
+          size="small"
+          disabled={actingUUID === params.row.submissionUUID}
+          onClick={() => setConfirm({ action: 'promote', row: params.row })}
+        >
+          Promote
+        </Button>
+      ),
+    },
+    {
+      field: 'reject',
+      headerName: 'Reject',
+      width: 110,
+      sortable: false,
+      renderCell: (params) => (
+        <Button
+          variant="contained"
+          color="error"
+          size="small"
+          disabled={actingUUID === params.row.submissionUUID}
+          onClick={() => setConfirm({ action: 'reject', row: params.row })}
+        >
+          Reject
+        </Button>
+      ),
+    },
   ];
 
   return (
@@ -92,11 +231,6 @@ export default function AdminProcessedSensorsV2({ processed }) {
         </Typography>
       </Paper>
 
-      <Alert severity="info" sx={{ mb: 2 }}>
-        Production promotion is not yet enabled for V2. These rows are
-        read-only previews of <code>groov-temp-v2-processed</code>.
-      </Alert>
-
       <Box sx={{ height: 320, width: '100%' }}>
         <DataGrid
           rows={rows}
@@ -108,6 +242,7 @@ export default function AdminProcessedSensorsV2({ processed }) {
         />
       </Box>
 
+      {/* View dialog */}
       <Dialog
         open={Boolean(viewing)}
         onClose={() => setViewing(null)}
@@ -128,6 +263,61 @@ export default function AdminProcessedSensorsV2({ processed }) {
             <SensorPageV2View sensor={viewing.data} hideEditButton />
           )}
         </DialogContent>
+      </Dialog>
+
+      {/* Confirmation dialog */}
+      <Dialog
+        open={Boolean(confirm)}
+        onClose={() => setConfirm(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>
+          {confirm?.action === 'promote'
+            ? 'Promote to production?'
+            : 'Reject submission?'}
+        </DialogTitle>
+        <DialogContent dividers>
+          {confirm && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="body2">
+                <strong>Aliases:</strong> {confirm.row.aliases}
+              </Typography>
+              <Typography variant="body2">
+                <strong>Type:</strong> {confirm.row.type}
+              </Typography>
+              <Typography variant="body2">
+                <strong>Proposed GRV ID:</strong> {confirm.row.proposed_grv_id}
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 1 }}
+              >
+                {confirm.action === 'promote'
+                  ? 'This will write the sensor to the live database and regenerate the public index and fingerprints.'
+                  : 'This discards the processed row. The original raw submission is unaffected.'}
+              </Typography>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirm(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color={confirm?.action === 'promote' ? 'success' : 'error'}
+            disabled={actingUUID === confirm?.row?.submissionUUID}
+            onClick={() => {
+              if (confirm?.action === 'promote') {
+                doPromote(confirm.row);
+              } else {
+                doReject(confirm.row);
+              }
+            }}
+          >
+            {confirm?.action === 'promote' ? 'Promote' : 'Reject'}
+          </Button>
+        </DialogActions>
       </Dialog>
     </Box>
   );

--- a/src/Components/About/Admin/v2/AdminProcessedSensorsV2.js
+++ b/src/Components/About/Admin/v2/AdminProcessedSensorsV2.js
@@ -54,7 +54,6 @@ export default function AdminProcessedSensorsV2({
     try {
       const { status, body } = await approveProcessedSensorV2(
         user,
-        row.category,
         row.submissionUUID
       );
       switch (status) {
@@ -106,7 +105,6 @@ export default function AdminProcessedSensorsV2({
     try {
       const { status, body } = await rejectProcessedSensorV2(
         user,
-        row.category,
         row.submissionUUID
       );
       if (status === 204) {

--- a/src/Components/About/Admin/v2/AdminPublishedSensorsV2.js
+++ b/src/Components/About/Admin/v2/AdminPublishedSensorsV2.js
@@ -28,6 +28,7 @@ export default function AdminPublishedSensorsV2({ user }) {
   const [deleteTarget, setDeleteTarget] = useState(null); // row | null
   const [confirmText, setConfirmText] = useState('');
   const [deleting, setDeleting] = useState(false);
+  const [search, setSearch] = useState('');
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -72,6 +73,16 @@ export default function AdminPublishedSensorsV2({ user }) {
       ligands: (s.ligands || []).join(', ') || 'None',
     }))
     .sort((a, b) => a.grv_id.localeCompare(b.grv_id));
+
+  // Text filter across every visible column so admins can quickly find a sensor
+  // (e.g. "D" test sensors, an organism, or a ligand) before deleting.
+  const query = search.trim().toLowerCase();
+  const filteredRows = query
+    ? rows.filter((r) =>
+        [r.grv_id, r.alias, r.uniprot_id, r.organism_name, r.category, r.ligands]
+          .some((v) => String(v ?? '').toLowerCase().includes(query))
+      )
+    : rows;
 
   const openDelete = (row) => {
     setDeleteTarget(row);
@@ -209,16 +220,41 @@ export default function AdminPublishedSensorsV2({ user }) {
       )}
 
       {!loading && !error && (
-        <Box sx={{ height: 360, width: '100%' }}>
-          <DataGrid
-            rows={rows}
-            columns={columns}
-            autoPageSize
-            rowsPerPageOptions={[5, 10, 25]}
-            density="compact"
-            getRowId={(r) => r.id}
-          />
-        </Box>
+        <>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              mb: 1.5,
+              flexWrap: 'wrap',
+            }}
+          >
+            <TextField
+              size="small"
+              label="Search sensors"
+              placeholder="GRV ID, alias, UniProt, organism, category, ligand…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              autoComplete="off"
+              sx={{ minWidth: { xs: '100%', sm: 360 } }}
+            />
+            <Typography variant="body2" color="text.secondary">
+              {filteredRows.length} of {rows.length} shown
+            </Typography>
+          </Box>
+          <Box sx={{ height: 360, width: '100%' }}>
+            <DataGrid
+              rows={filteredRows}
+              columns={columns}
+              autoPageSize
+              rowsPerPageOptions={[5, 10, 25]}
+              density="compact"
+              getRowId={(r) => r.id}
+            />
+          </Box>
+        </>
       )}
 
       {/* Delete confirmation dialog */}

--- a/src/Components/About/Admin/v2/AdminPublishedSensorsV2.js
+++ b/src/Components/About/Admin/v2/AdminPublishedSensorsV2.js
@@ -1,0 +1,292 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import { useSnackbar } from 'notistack';
+
+import {
+  deleteSensorV2,
+  fetchPublishedSensorsV2,
+} from '../../../../lib/api/v2Admin';
+
+export default function AdminPublishedSensorsV2({ user }) {
+  const [sensors, setSensors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [deleteTarget, setDeleteTarget] = useState(null); // row | null
+  const [confirmText, setConfirmText] = useState('');
+  const [deleting, setDeleting] = useState(false);
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const loadSensors = useCallback(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchPublishedSensorsV2()
+      .then(({ sensors: s }) => {
+        if (cancelled) return;
+        setSensors(s ?? []);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err.message || 'Failed to load published sensors');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const cleanup = loadSensors();
+    return cleanup;
+  }, [loadSensors]);
+
+  const rows = sensors.map((s) => ({
+    id: s.id,
+    grv_id: s.id,
+    alias: s.alias,
+    uniprot_id: s.uniprot_id,
+    organism_name: s.organism_name,
+    category: s.category,
+    ligands: (s.ligands || []).join(', ') || 'None',
+  }));
+
+  const openDelete = (row) => {
+    setDeleteTarget(row);
+    setConfirmText('');
+  };
+
+  const closeDelete = () => {
+    setDeleteTarget(null);
+    setConfirmText('');
+  };
+
+  const doDelete = async () => {
+    if (!deleteTarget) return;
+    const row = deleteTarget;
+    setDeleting(true);
+    try {
+      const { status, body } = await deleteSensorV2(user, row.category, row.grv_id);
+      switch (status) {
+        case 200:
+          enqueueSnackbar(`Deleted ${row.grv_id}`, {
+            variant: 'success',
+            preventDuplicate: true,
+          });
+          setSensors((prev) => prev.filter((s) => s.id !== row.id));
+          closeDelete();
+          break;
+        case 404:
+          enqueueSnackbar(`Not found (already deleted?): ${row.grv_id}`, {
+            variant: 'warning',
+            preventDuplicate: true,
+          });
+          setSensors((prev) => prev.filter((s) => s.id !== row.id));
+          closeDelete();
+          break;
+        case 400:
+          enqueueSnackbar(`Invalid: ${body.message || 'bad input'}`, {
+            variant: 'error',
+            preventDuplicate: true,
+          });
+          break;
+        default:
+          enqueueSnackbar(
+            `Error deleting ${row.grv_id}: ${body.message || 'HTTP ' + status}`,
+            { variant: 'error', preventDuplicate: true }
+          );
+      }
+    } catch (err) {
+      enqueueSnackbar(`Network error: ${err.message}`, {
+        variant: 'error',
+        preventDuplicate: true,
+      });
+    } finally {
+      setDeleting(false);
+      setConfirmText('');
+    }
+  };
+
+  const columns = [
+    { field: 'grv_id', headerName: 'GRV ID', width: 140 },
+    { field: 'alias', headerName: 'Alias', flex: 1, minWidth: 160 },
+    { field: 'uniprot_id', headerName: 'UniProt ID', width: 120 },
+    { field: 'organism_name', headerName: 'Organism', flex: 1, minWidth: 160 },
+    { field: 'category', headerName: 'Category', width: 120 },
+    { field: 'ligands', headerName: 'Ligands', flex: 1, minWidth: 160 },
+    {
+      field: 'delete',
+      headerName: 'Delete',
+      width: 110,
+      sortable: false,
+      renderCell: (params) => (
+        <Button
+          variant="contained"
+          color="error"
+          size="small"
+          onClick={() => openDelete(params.row)}
+        >
+          Delete
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <Box sx={{ mt: 4, mb: 4 }}>
+      <Paper
+        sx={{
+          p: 3,
+          borderRadius: 2,
+          mb: 3,
+          background:
+            'linear-gradient(135deg, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0.05) 100%)',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 2,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Box>
+            <Typography variant="h5" component="h2" sx={{ fontWeight: 600, mb: 1 }}>
+              Published Sensors (Production)
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6 }}>
+              These sensors are live. Deletion is{' '}
+              <strong>permanent and irreversible</strong> — it removes the
+              production DynamoDB row, R2 sensor JSON, family + main indexes,
+              and triggers a fingerprint rebuild.
+            </Typography>
+          </Box>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={loadSensors}
+            disabled={loading}
+          >
+            Refresh
+          </Button>
+        </Box>
+      </Paper>
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {!loading && error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {!loading && !error && (
+        <Box sx={{ height: 360, width: '100%' }}>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            autoPageSize
+            rowsPerPageOptions={[5, 10, 25]}
+            density="compact"
+            getRowId={(r) => r.id}
+          />
+        </Box>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onClose={closeDelete}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Delete sensor permanently?</DialogTitle>
+        <DialogContent dividers>
+          {deleteTarget && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>GRV ID:</strong> {deleteTarget.grv_id}
+              </Typography>
+              <Typography variant="body2">
+                <strong>Alias:</strong> {deleteTarget.alias}
+              </Typography>
+              <Typography variant="body2">
+                <strong>Category:</strong> {deleteTarget.category}
+              </Typography>
+              <Typography variant="body2" color="error" sx={{ mt: 0.5 }}>
+                This action <strong>cannot be undone</strong>. It will
+                permanently remove:
+              </Typography>
+              <Box
+                component="ul"
+                sx={{ m: 0, pl: 2.5 }}
+              >
+                <Typography component="li" variant="body2">
+                  Production DynamoDB row
+                </Typography>
+                <Typography component="li" variant="body2">
+                  R2 sensor JSON
+                </Typography>
+                <Typography component="li" variant="body2">
+                  Family index + main index entries
+                </Typography>
+                <Typography component="li" variant="body2">
+                  Molecular fingerprints (rebuilt on next publish)
+                </Typography>
+              </Box>
+              <TextField
+                label={`Type ${deleteTarget.grv_id} to confirm`}
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                size="small"
+                fullWidth
+                sx={{ mt: 1 }}
+                autoComplete="off"
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDelete} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            disabled={
+              deleting ||
+              confirmText.trim() !== (deleteTarget?.grv_id ?? '')
+            }
+            onClick={doDelete}
+          >
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/Components/About/Admin/v2/AdminPublishedSensorsV2.js
+++ b/src/Components/About/Admin/v2/AdminPublishedSensorsV2.js
@@ -59,15 +59,19 @@ export default function AdminPublishedSensorsV2({ user }) {
     return cleanup;
   }, [loadSensors]);
 
-  const rows = sensors.map((s) => ({
-    id: s.id,
-    grv_id: s.id,
-    alias: s.alias,
-    uniprot_id: s.uniprot_id,
-    organism_name: s.organism_name,
-    category: s.category,
-    ligands: (s.ligands || []).join(', ') || 'None',
-  }));
+  // index.json appends new sensors at the end; sort by GRV ID so rows slot in
+  // by prefix/number (zero-padded IDs sort correctly as strings: A < D < G).
+  const rows = sensors
+    .map((s) => ({
+      id: s.id,
+      grv_id: s.id,
+      alias: s.alias,
+      uniprot_id: s.uniprot_id,
+      organism_name: s.organism_name,
+      category: s.category,
+      ligands: (s.ligands || []).join(', ') || 'None',
+    }))
+    .sort((a, b) => a.grv_id.localeCompare(b.grv_id));
 
   const openDelete = (row) => {
     setDeleteTarget(row);

--- a/src/Components/About/Admin/v2/AdminV2.js
+++ b/src/Components/About/Admin/v2/AdminV2.js
@@ -104,7 +104,10 @@ export default function AdminV2() {
 
   return (
     <>
-      <Container maxWidth="xl" sx={{ py: 4 }}>
+      <Container
+        maxWidth={false}
+        sx={{ py: 4, width: { xs: '100%', lg: '60%' }, mx: 'auto' }}
+      >
         <Typography
           variant="h2"
           component="h1"

--- a/src/Components/About/Admin/v2/AdminV2.js
+++ b/src/Components/About/Admin/v2/AdminV2.js
@@ -18,6 +18,7 @@ import {
 } from '../../../../lib/api/v2Admin';
 import AdminTempSensorsV2 from './AdminTempSensorsV2';
 import AdminProcessedSensorsV2 from './AdminProcessedSensorsV2';
+import AdminPublishedSensorsV2 from './AdminPublishedSensorsV2';
 
 export default function AdminV2() {
   const user = useUserStore((s) => s.user);
@@ -87,6 +88,18 @@ export default function AdminV2() {
     );
   };
 
+  const handlePromoted = (submissionUUID) => {
+    setProcessed((prev) =>
+      (prev ?? []).filter((p) => p.submissionUUID !== submissionUUID)
+    );
+  };
+
+  const handleProcessedRejected = (submissionUUID) => {
+    setProcessed((prev) =>
+      (prev ?? []).filter((p) => p.submissionUUID !== submissionUUID)
+    );
+  };
+
   const isLoading = submissions === null || processed === null;
 
   return (
@@ -126,7 +139,12 @@ export default function AdminV2() {
           </Box>
         ) : (
           <>
-            <AdminProcessedSensorsV2 processed={processed} />
+            <AdminProcessedSensorsV2
+              processed={processed}
+              user={user}
+              onPromoted={handlePromoted}
+              onRejected={handleProcessedRejected}
+            />
             <AdminTempSensorsV2
               user={user}
               submissions={submissions}
@@ -135,6 +153,7 @@ export default function AdminV2() {
               onRejected={handleRejected}
               setApproveIsLoading={setApproveIsLoading}
             />
+            <AdminPublishedSensorsV2 user={user} />
           </>
         )}
       </Container>

--- a/src/Components/RegFamilyTiles.js
+++ b/src/Components/RegFamilyTiles.js
@@ -44,7 +44,14 @@ export default function RegFamilyTiles() {
     { image: '/LuxR-family.png', family: 'LuxR' },
     { image: '/IclR-family.png', family: 'IclR' },
     { image: '/Other-family.png', family: 'Other' },
+    // Two-component systems collapse into a single "Dual" bucket on the backend
+    // (R2 family index v2/indexes/dual.json). No dedicated artwork yet, so reuse Other.
+    { image: '/Other-family.png', family: 'Dual', label: 'Two-Component' },
   ];
+
+  // Display label overrides where the backend category name isn't the friendliest UI label.
+  const FAMILY_LABELS = { Dual: 'Two-Component' };
+  const labelFor = (fam) => FAMILY_LABELS[fam] ?? fam;
 
   const familyDescriptions = {
     "TetR": "Highly represented. Oftentimes dimeric repressors that bind to structurally diverse ligands",
@@ -55,7 +62,8 @@ export default function RegFamilyTiles() {
     "GntR": "Oftentimes dimeric repressors that bind to structurally diverse ligands",
     "LuxR": "Oftentimes dimeric activators involved in quorum sensing that bind to homoserine lactones",
     "IclR": "Oftentimes dimeric repressors that bind to organic acids and small aromatic ligands",
-    "Other": "All other families, including ROK, AsnC, TrpR, and DeoR"
+    "Other": "All other families, including ROK, AsnC, TrpR, and DeoR",
+    "Dual": ""
   }
 
   const MainContent = ({ family = "all" }) => {
@@ -75,7 +83,9 @@ export default function RegFamilyTiles() {
               mt:3, 
             }}
           >
-            {family === "all" ? "All Sensor Families" : `${family} Family Sensors`}
+            {family === "all"
+              ? "All Sensor Families"
+              : `${labelFor(family)}${family === "Dual" ? "" : " Family"} Sensors`}
           </Typography>
           <Typography
             variant="body1"
@@ -189,7 +199,7 @@ export default function RegFamilyTiles() {
                       color: 'text.primary',
                     }}
                   >
-                    {item.family}
+                    {labelFor(item.family)}
                   </Typography>
                 </CardActionArea>
               </Card>
@@ -245,7 +255,7 @@ export default function RegFamilyTiles() {
                   pb: 1,
                 }}
               >
-                {item.family}
+                {labelFor(item.family)}
               </Typography>
             </CardActionArea>
           </Card>

--- a/src/Components/Sensor_Components/OperatorViewer.js
+++ b/src/Components/Sensor_Components/OperatorViewer.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
+import { DNALogo } from 'logojs-react';
+
 import {
   Box,
   Grid,
@@ -9,6 +11,20 @@ import {
   Pagination,
   Stack,
 } from '@mui/material';
+
+// Build a position-probability matrix (A, C, G, T) for a single operator
+// sequence so we can render the same DNA logo shown on the sensor page. Each
+// position is a definite base for one sequence, so the probability is 1.0.
+const BASE_INDEX = { A: 0, C: 1, G: 2, T: 3 };
+const buildSingleSequencePPM = (sequence) => {
+  const seq = (sequence || '').toUpperCase();
+  if (!seq || !/^[ATCG]+$/.test(seq)) return null;
+  return [...seq].map((char) => {
+    const base = [0, 0, 0, 0];
+    base[BASE_INDEX[char]] = 1;
+    return base;
+  });
+};
 
 export default function OperatorViewer(props) {
   const [operatorNumber, setOperatorNumber] = useState(1);
@@ -24,6 +40,8 @@ export default function OperatorViewer(props) {
       setOperator(props.operators[operatorNumber - 1]);
     }
   }, [operatorNumber, props.operators]);
+
+  const logoMatrix = buildSingleSequencePPM(operator['sequence']);
 
   return (
     <Box sx={{ flexGrow: 1 }}>
@@ -65,6 +83,15 @@ export default function OperatorViewer(props) {
                 Method: {operator['method']}
               </Typography>
             </Box>
+
+            {/* DNA logo (same render as the sensor page) */}
+            {logoMatrix && (
+              <Grid container>
+                <Grid item xs={12} sx={{ overflowX: 'auto' }}>
+                  <DNALogo ppm={logoMatrix} height="90px" yAxisMax={2.5} />
+                </Grid>
+              </Grid>
+            )}
 
             {/* Operator Sequence */}
             <Grid container>

--- a/src/Components/Sensor_Components/SensorPageV2.js
+++ b/src/Components/Sensor_Components/SensorPageV2.js
@@ -31,6 +31,7 @@ const ID_PREFIX_TO_CATEGORY = {
   G: 'gntr',
   I: 'iclr',
   Z: 'other',
+  D: 'dual', // two-component systems (TWO_COMPONENT_PREFIX on the backend)
 };
 
 function getCategoryFromId(id) {

--- a/src/Components/Sensor_Components/V2/ProteinPanel.js
+++ b/src/Components/Sensor_Components/V2/ProteinPanel.js
@@ -68,16 +68,28 @@ const MissingDataCard = ({ title, message }) => (
  */
 export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNightingaleLoaded }) {
   const origin = protein.origin?.[0];
+  // uniprot_id / refseq_id are optional (item 7) — mutant/engineered proteins
+  // may lack them. Fall back to the alias for keys/canvas ids that must be
+  // stable & unique across proteins, and omit ID rows/links when absent.
+  const keyId = protein.uniprot_id || protein.alias;
 
   const metadataTableData = {
-    'UniProt ID': {
-      name: protein.uniprot_id,
-      link: { url: `https://www.uniprot.org/uniprot/${protein.uniprot_id}` },
-    },
-    'RefSeq ID': {
-      name: protein.refseq_id,
-      link: { url: `https://www.ncbi.nlm.nih.gov/protein/${protein.refseq_id}` },
-    },
+    ...(protein.uniprot_id
+      ? {
+          'UniProt ID': {
+            name: protein.uniprot_id,
+            link: { url: `https://www.uniprot.org/uniprot/${protein.uniprot_id}` },
+          },
+        }
+      : {}),
+    ...(protein.refseq_id
+      ? {
+          'RefSeq ID': {
+            name: protein.refseq_id,
+            link: { url: `https://www.ncbi.nlm.nih.gov/protein/${protein.refseq_id}` },
+          },
+        }
+      : {}),
     'KEGG ID': {
       name: protein.kegg_id || 'None',
       ...(protein.kegg_id && protein.kegg_id !== 'None'
@@ -104,7 +116,8 @@ export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNighti
 
   const structureIDs = [
     ...(protein.structures?.map((s) => s.ID) ?? []),
-    `AF-${protein.uniprot_id}-F1`,
+    // AlphaFold prediction only exists when there's a UniProt accession.
+    ...(protein.uniprot_id ? [`AF-${protein.uniprot_id}-F1`] : []),
   ];
 
   const hasDNA = protein.dna?.length > 0;
@@ -112,6 +125,9 @@ export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNighti
   const hasContext = protein.context?.length > 0 && protein.context[0]?.operon_dir?.length > 0;
   const hasReferences = protein.references?.length > 0;
   const hasSequence = !!protein.sequence;
+  // ProteinStructure assumes at least one ID — with no PDB and no UniProt
+  // (hence no AlphaFold) the list is empty, so show the missing-data card.
+  const hasStructure = structureIDs.length > 0;
 
   return (
     <Container maxWidth="xl" disableGutters sx={{ py: 1 }}>
@@ -131,8 +147,8 @@ export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNighti
               <SectionCard title="Stimulus" icon={<HexagonOutlinedIcon color="primary" />}>
                 <StimulusViewer
                   stimulus={protein.stimulus}
-                  canvasId={protein.uniprot_id}
-                  key={protein.uniprot_id}
+                  canvasId={keyId}
+                  key={keyId}
                 />
               </SectionCard>
             ) : (
@@ -141,15 +157,19 @@ export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNighti
           </Grid>
 
           <Grid size={{ xs: 12, md: 6 }}>
-            <SectionCard title="Structure" icon={<SwapCallsOutlinedIcon color="primary" />}>
-              <ProteinStructure
-                key={protein.uniprot_id}
-                structureIDs={structureIDs}
-                uniprotID={protein.uniprot_id}
-                isComponentLoaded={isNightingaleLoaded}
-                setIsComponentLoaded={setIsNightingaleLoaded}
-              />
-            </SectionCard>
+            {hasStructure ? (
+              <SectionCard title="Structure" icon={<SwapCallsOutlinedIcon color="primary" />}>
+                <ProteinStructure
+                  key={keyId}
+                  structureIDs={structureIDs}
+                  uniprotID={protein.uniprot_id}
+                  isComponentLoaded={isNightingaleLoaded}
+                  setIsComponentLoaded={setIsNightingaleLoaded}
+                />
+              </SectionCard>
+            ) : (
+              <MissingDataCard title="Structure" message="No structure available" />
+            )}
           </Grid>
         </Grid>
 
@@ -183,7 +203,7 @@ export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNighti
                 <GenomeContextV2
                   context={protein.context}
                   alias={protein.alias}
-                  key={protein.uniprot_id}
+                  key={keyId}
                 />
               </SectionCard>
             ) : (
@@ -198,7 +218,7 @@ export default function ProteinPanel({ protein, isNightingaleLoaded, setIsNighti
           <Grid container>
             <Grid size={12}>
               <SectionCard title="References" icon={<FeedOutlinedIcon color="primary" />}>
-                <ReferenceViewerV2 references={protein.references} key={protein.uniprot_id} />
+                <ReferenceViewerV2 references={protein.references} key={keyId} />
               </SectionCard>
             </Grid>
           </Grid>

--- a/src/Components/addSensor/v2_form/SensorMetaTab.js
+++ b/src/Components/addSensor/v2_form/SensorMetaTab.js
@@ -1,15 +1,41 @@
+import { useEffect } from 'react';
 import { Box, Typography } from '@mui/material';
+import { useFormikContext } from 'formik';
 import { FormikTextInput } from '../../form-inputs/FormikTextInput';
 import { FormikSelectInput } from '../../form-inputs/FormikSelectInput';
 
-const mechanismOptions = [
+// Single-component transcription factors pick one of the apo/co mechanisms.
+const SINGLE_COMPONENT_MECHANISMS = [
   'Apo-repressor',
   'Co-repressor',
   'Apo-activator',
   'Co-activator',
 ];
 
+// A two-/multi-component system (2+ proteins) always works via signal
+// transduction — the apo/co-repressor distinction doesn't apply.
+const MULTI_COMPONENT_MECHANISM = 'Signal transduction';
+
 export default function SensorMetaTab() {
+  const { values, setFieldValue } = useFormikContext();
+  const isMultiComponent = (values.proteins?.length ?? 1) >= 2;
+  const mechanism = values.sensor?.mechanism;
+
+  // Keep the mechanism consistent with the protein count: lock multi-component
+  // sensors to "Signal transduction", and clear it when dropping back to a
+  // single protein so the user re-picks a valid single-component mechanism.
+  useEffect(() => {
+    if (isMultiComponent && mechanism !== MULTI_COMPONENT_MECHANISM) {
+      setFieldValue('sensor.mechanism', MULTI_COMPONENT_MECHANISM);
+    } else if (!isMultiComponent && mechanism === MULTI_COMPONENT_MECHANISM) {
+      setFieldValue('sensor.mechanism', '');
+    }
+  }, [isMultiComponent, mechanism, setFieldValue]);
+
+  const mechanismOptions = isMultiComponent
+    ? [MULTI_COMPONENT_MECHANISM]
+    : SINGLE_COMPONENT_MECHANISMS;
+
   return (
     <Box
       display="grid"
@@ -30,7 +56,14 @@ export default function SensorMetaTab() {
           name="sensor.mechanism"
           label="Mechanism"
           options={mechanismOptions}
+          disabled={isMultiComponent}
         />
+        {isMultiComponent && (
+          <Typography variant="caption" color="text.secondary">
+            Multi-component sensor (2+ proteins) — mechanism is set to
+            “Signal transduction” automatically.
+          </Typography>
+        )}
       </Box>
       <Box gridColumn="span 12">
         <FormikTextInput

--- a/src/Components/addSensor/v2_form/SensorMetaTab.js
+++ b/src/Components/addSensor/v2_form/SensorMetaTab.js
@@ -16,6 +16,9 @@ const SINGLE_COMPONENT_MECHANISMS = [
 // transduction — the apo/co-repressor distinction doesn't apply.
 const MULTI_COMPONENT_MECHANISM = 'Signal transduction';
 
+// Structural families that only apply to proteins within a two-component system.
+const TWO_COMPONENT_FAMILIES = ['OmpR', 'HisKA'];
+
 export default function SensorMetaTab() {
   const { values, setFieldValue } = useFormikContext();
   const isMultiComponent = (values.proteins?.length ?? 1) >= 2;
@@ -31,6 +34,18 @@ export default function SensorMetaTab() {
       setFieldValue('sensor.mechanism', '');
     }
   }, [isMultiComponent, mechanism, setFieldValue]);
+
+  // OmpR/HisKA are only offered for two-component systems. If the user drops back
+  // to a single protein, clear any protein still set to one of those families so
+  // the now-invalid value doesn't linger (the dropdown hides it at that point).
+  useEffect(() => {
+    if (isMultiComponent) return;
+    (values.proteins ?? []).forEach((protein, i) => {
+      if (TWO_COMPONENT_FAMILIES.includes(protein?.family)) {
+        setFieldValue(`proteins.${i}.family`, '');
+      }
+    });
+  }, [isMultiComponent, values.proteins, setFieldValue]);
 
   const mechanismOptions = isMultiComponent
     ? [MULTI_COMPONENT_MECHANISM]

--- a/src/Components/addSensor/v2_form/tabViews/AboutProteinTab.js
+++ b/src/Components/addSensor/v2_form/tabViews/AboutProteinTab.js
@@ -44,8 +44,8 @@ export default function AboutProteinTab({ fieldPrefix }) {
       <Box gridColumn="span 12">
         <FormikTextInput
           name={f('uniProtID')}
-          label="UniProt ID (optional)"
-          helperText='e.g. "P0ACT4". Optional — leave blank if the protein has no UniProt entry (no sequence or structure will be fetched).'
+          label="UniProt ID"
+          helperText='e.g. "P0ACT4". Required — used to fetch the protein sequence, structures, and cross-references.'
         />
       </Box>
       <Box gridColumn="span 12">

--- a/src/Components/addSensor/v2_form/tabViews/AboutProteinTab.js
+++ b/src/Components/addSensor/v2_form/tabViews/AboutProteinTab.js
@@ -28,15 +28,15 @@ export default function AboutProteinTab({ fieldPrefix }) {
       <Box gridColumn="span 12">
         <FormikTextInput
           name={f('accession')}
-          label="RefSeq"
-          helperText='NCBI accession, e.g. "WP_000123456.1".'
+          label="RefSeq (optional)"
+          helperText='NCBI accession, e.g. "WP_000123456.1". Optional — leave blank for engineered/mutant proteins without one (no operon will be resolved).'
         />
       </Box>
       <Box gridColumn="span 12">
         <FormikTextInput
           name={f('uniProtID')}
-          label="UniProt ID"
-          helperText='e.g. "P0ACT4".'
+          label="UniProt ID (optional)"
+          helperText='e.g. "P0ACT4". Optional — leave blank if the protein has no UniProt entry (no sequence or structure will be fetched).'
         />
       </Box>
       <Box gridColumn="span 12">

--- a/src/Components/addSensor/v2_form/tabViews/AboutProteinTab.js
+++ b/src/Components/addSensor/v2_form/tabViews/AboutProteinTab.js
@@ -1,10 +1,19 @@
 import { Box, Typography } from '@mui/material';
+import { useFormikContext } from 'formik';
 import { FormikTextInput } from '../../../form-inputs/FormikTextInput';
 import { FormikSelectInput } from '../../../form-inputs/FormikSelectInput';
 
 const FAMILY_OPTIONS = ['TetR', 'LysR', 'AraC', 'MarR', 'LacI', 'GntR', 'LuxR', 'IclR', 'Other'];
+// OmpR/HisKA describe individual proteins within a two-component system, so they
+// only appear once the submission has a second protein.
+const TWO_COMPONENT_FAMILY_OPTIONS = ['OmpR', 'HisKA'];
 
 export default function AboutProteinTab({ fieldPrefix }) {
+  const { values } = useFormikContext();
+  const isMultiProtein = (values?.proteins?.length ?? 1) >= 2;
+  const familyOptions = isMultiProtein
+    ? [...FAMILY_OPTIONS, ...TWO_COMPONENT_FAMILY_OPTIONS]
+    : FAMILY_OPTIONS;
   const f = (name) => `${fieldPrefix}.${name}`;
   return (
     <Box
@@ -43,7 +52,7 @@ export default function AboutProteinTab({ fieldPrefix }) {
         <FormikSelectInput
           name={f('family')}
           label="Family"
-          options={FAMILY_OPTIONS}
+          options={familyOptions}
           helperText="Transcription factor family this protein belongs to."
         />
       </Box>

--- a/src/Components/addSensor/v2_form/tabViews/StimuliTab.js
+++ b/src/Components/addSensor/v2_form/tabViews/StimuliTab.js
@@ -93,7 +93,7 @@ export default function StimuliTab({ fieldPrefix }) {
           >
             {STIMULUS_TYPES.map((t) => (
               <MenuItem key={t.value} value={t.value}>
-                {t.label}{counts[t.value] > 0 ? ` (${counts[t.value]})` : ''}
+                {t.label}{counts[t.value] > 1 ? ` (${counts[t.value]})` : ''}
               </MenuItem>
             ))}
           </Select>

--- a/src/Components/addSensor/v2_form/tabViews/cards/LigandCard.js
+++ b/src/Components/addSensor/v2_form/tabViews/cards/LigandCard.js
@@ -15,7 +15,7 @@ const ligandMethods = [
   'EMSA', 'DNase footprinting', 'Isothermal titration calorimetry',
   'Surface plasmon resonance', 'Synthetic regulation', 'Fluorescence polarization',
   'Thermal shift', 'Spectrophotometric competition', 'Spectral shift',
-  'DNA affinity chromatography',
+  'DNA affinity chromatography', 'Autophosphorylation assay',
 ];
 
 export default function LigandCard({ index, fieldPrefix }) {

--- a/src/Components/addSensor/v2_form/tabViews/cards/StimulusCard.js
+++ b/src/Components/addSensor/v2_form/tabViews/cards/StimulusCard.js
@@ -45,16 +45,16 @@ export default function StimulusCard({
           <Box mb={2}>
             <FormikSelectInput name={f('regulatory_effect')} label="Regulatory effect (optional)" options={['activates', 'represses']} />
           </Box>
-          <Box mb={2}><FormikTextInput name={f('doi')} label="DOI (optional)" /></Box>
+          <Box mb={2}><FormikTextInput name={f('doi')} label="DOI" /></Box>
           <Box display="flex" mb={2}>
             <FormControl fullWidth sx={{ mr: 2 }}>
-              <FormikSelectInput name={f('fig_type')} label="Figure Type (optional)" options={figureTypes} />
+              <FormikSelectInput name={f('fig_type')} label="Figure Type" options={figureTypes} />
             </FormControl>
             <FormControl fullWidth sx={{ ml: 2 }}>
-              <FormikTextInput name={f('ref_figure')} label="Figure Number (optional)" />
+              <FormikTextInput name={f('ref_figure')} label="Figure Number" />
             </FormControl>
           </Box>
-          <Box mb={2}><FormikTextInput name={f('method')} label="Method (optional)" /></Box>
+          <Box mb={2}><FormikTextInput name={f('method')} label="Method" /></Box>
         </Collapse>
       </Box>
     </>

--- a/src/aws-exports.js
+++ b/src/aws-exports.js
@@ -14,7 +14,9 @@ const awsConfig = {
       domain: 'groov.auth.us-east-2.amazoncognito.com',
       scope: ['email', 'openid', 'profile'],
       // Should be restored to https://www.groov.bio/account/ after local development
+      // Should be http://localhost:3000/account/ for local development
       redirectSignIn: 'https://www.groov.bio/account/',
+      // should be http://localhost:3000/ for local development
       // Should be restored to https://www.groov.bio/ after local development
       redirectSignOut: 'https://www.groov.bio/',
       responseType: 'code',

--- a/src/lib/api/v2Admin.js
+++ b/src/lib/api/v2Admin.js
@@ -104,28 +104,31 @@ export async function deleteTempV2(user, submissionUUID) {
 
 /**
  * Promote a processed temp sensor into the live published database.
+ * Processed-temp rows are keyed by submissionUUID alone (PK="PROCESSED"); the
+ * backend derives the category from the row's data, so no category is sent.
  * Returns { status, body } so the caller can branch on:
  *   200 success { message, grv_id, category }
  *   404 not found | 409 already promoted | 400 bad input | 500 error
  */
-export async function approveProcessedSensorV2(user, category, submissionUUID) {
+export async function approveProcessedSensorV2(user, submissionUUID) {
   const res = await fetch(`${V2_API_BASE}/v2/approveProcessedSensor`, {
     method: 'POST',
     headers: { ...authHeaders(user), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ category, submissionUUID }),
+    body: JSON.stringify({ submissionUUID }),
   });
   return { status: res.status, body: await parseJsonOrEmpty(res) };
 }
 
 /**
  * Reject (delete) a processed temp sensor without promoting it.
+ * Keyed by submissionUUID alone (PK="PROCESSED").
  * Returns { status, body } — 204 success, 404 already gone.
  */
-export async function rejectProcessedSensorV2(user, category, submissionUUID) {
+export async function rejectProcessedSensorV2(user, submissionUUID) {
   const res = await fetch(`${V2_API_BASE}/v2/rejectProcessedSensor`, {
     method: 'POST',
     headers: { ...authHeaders(user), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ category, submissionUUID }),
+    body: JSON.stringify({ submissionUUID }),
   });
   return { status: res.status, body: await parseJsonOrEmpty(res) };
 }
@@ -148,11 +151,18 @@ export async function deleteSensorV2(user, category, grv_id) {
 /**
  * Fetch the public R2 CDN index of all published sensors — same source the
  * public sensor tables use. No auth required.
+ *
+ * The admin delete console must reflect current production state, so we bypass
+ * the browser + Cloudflare edge cache: `cache: 'no-store'` skips the browser
+ * cache, and the unique `?t=` query string forces a CDN cache miss (the public
+ * tables intentionally use the cached URL without the buster).
  * Returns { stats: { regulators, ligands }, sensors: [ { id, alias,
  *   uniprot_id, organism_name, category, ligands[] } ] }
  */
 export async function fetchPublishedSensorsV2() {
-  const res = await fetch('https://groov-api.com/v2/index.json');
+  const res = await fetch(`https://groov-api.com/v2/index.json?t=${Date.now()}`, {
+    cache: 'no-store',
+  });
   if (!res.ok) {
     throw new Error(`Failed to load published sensors (${res.status})`);
   }

--- a/src/lib/api/v2Admin.js
+++ b/src/lib/api/v2Admin.js
@@ -101,3 +101,60 @@ export async function deleteTempV2(user, submissionUUID) {
   });
   return { status: res.status, body: await parseJsonOrEmpty(res) };
 }
+
+/**
+ * Promote a processed temp sensor into the live published database.
+ * Returns { status, body } so the caller can branch on:
+ *   200 success { message, grv_id, category }
+ *   404 not found | 409 already promoted | 400 bad input | 500 error
+ */
+export async function approveProcessedSensorV2(user, category, submissionUUID) {
+  const res = await fetch(`${V2_API_BASE}/v2/approveProcessedSensor`, {
+    method: 'POST',
+    headers: { ...authHeaders(user), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category, submissionUUID }),
+  });
+  return { status: res.status, body: await parseJsonOrEmpty(res) };
+}
+
+/**
+ * Reject (delete) a processed temp sensor without promoting it.
+ * Returns { status, body } — 204 success, 404 already gone.
+ */
+export async function rejectProcessedSensorV2(user, category, submissionUUID) {
+  const res = await fetch(`${V2_API_BASE}/v2/rejectProcessedSensor`, {
+    method: 'POST',
+    headers: { ...authHeaders(user), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category, submissionUUID }),
+  });
+  return { status: res.status, body: await parseJsonOrEmpty(res) };
+}
+
+/**
+ * Delete a live published sensor by grv_id.
+ * Returns { status, body } so the caller can branch on:
+ *   200 success { message, grv_id, category }
+ *   404 not found | 400 bad input | 500 error
+ */
+export async function deleteSensorV2(user, category, grv_id) {
+  const res = await fetch(`${V2_API_BASE}/v2/deleteSensor`, {
+    method: 'POST',
+    headers: { ...authHeaders(user), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category, grv_id }),
+  });
+  return { status: res.status, body: await parseJsonOrEmpty(res) };
+}
+
+/**
+ * Fetch the public R2 CDN index of all published sensors — same source the
+ * public sensor tables use. No auth required.
+ * Returns { stats: { regulators, ligands }, sensors: [ { id, alias,
+ *   uniprot_id, organism_name, category, ligands[] } ] }
+ */
+export async function fetchPublishedSensorsV2() {
+  const res = await fetch('https://groov-api.com/v2/index.json');
+  if (!res.ok) {
+    throw new Error(`Failed to load published sensors (${res.status})`);
+  }
+  return res.json();
+}

--- a/src/lib/constants/v2_form/validationSchema.js
+++ b/src/lib/constants/v2_form/validationSchema.js
@@ -45,6 +45,8 @@ const mechanismValues = [
   'Apo-activator',
   'Co-repressor',
   'Co-activator',
+  // Multi-component (two-component) systems — auto-selected when 2+ proteins.
+  'Signal transduction',
 ];
 
 const familyValues = ['TetR', 'LysR', 'AraC', 'MarR', 'LacI', 'GntR', 'LuxR', 'IclR', 'Other'];
@@ -219,22 +221,25 @@ const operatorItemSchema = Yup.object().shape({
   kd_unit: Yup.string().oneOf(kdUnitValues, 'Invalid Kd unit').notRequired(),
 });
 
+// Light/temperature entries only exist when the user toggles the section on, so
+// every field is required for a present entry (DOI, figure, and method included
+// — they reference the same evidence we require for ligands/operators).
 const lightStimulusSchema = Yup.object().shape({
-  wavelength: optionalNumber,
+  wavelength: Yup.number().typeError('Wavelength is required').required('Wavelength is required'),
   regulatory_effect: Yup.string().oneOf(['activates', 'represses', ''], 'Must be "activates" or "represses"').notRequired(),
-  doi: Yup.string().matches(doiValidation, { message: 'Invalid DOI', excludeEmptyString: true }),
-  method: Yup.string().notRequired(),
-  ref_figure: Yup.string().matches(figurePattern, { message: 'Invalid figure', excludeEmptyString: true }),
-  fig_type: Yup.string().oneOf([...figureTypes, ''], 'Invalid figure type'),
+  doi: Yup.string().required('DOI reference is required').matches(doiValidation, { message: 'Invalid DOI', excludeEmptyString: true }),
+  method: Yup.string().required('Method is required'),
+  fig_type: Yup.string().oneOf(figureTypes, 'Invalid figure type').required('Figure type is required'),
+  ref_figure: Yup.string().required('Figure number is required').matches(figurePattern, { message: 'Invalid figure', excludeEmptyString: true }),
 });
 
 const temperatureStimulusSchema = Yup.object().shape({
-  temperature: optionalNumber,
+  temperature: Yup.number().typeError('Temperature is required').required('Temperature is required'),
   regulatory_effect: Yup.string().oneOf(['activates', 'represses', ''], 'Must be "activates" or "represses"').notRequired(),
-  doi: Yup.string().matches(doiValidation, { message: 'Invalid DOI', excludeEmptyString: true }),
-  method: Yup.string().notRequired(),
-  ref_figure: Yup.string().matches(figurePattern, { message: 'Invalid figure', excludeEmptyString: true }),
-  fig_type: Yup.string().oneOf([...figureTypes, ''], 'Invalid figure type'),
+  doi: Yup.string().required('DOI reference is required').matches(doiValidation, { message: 'Invalid DOI', excludeEmptyString: true }),
+  method: Yup.string().required('Method is required'),
+  fig_type: Yup.string().oneOf(figureTypes, 'Invalid figure type').required('Figure type is required'),
+  ref_figure: Yup.string().required('Figure number is required').matches(figurePattern, { message: 'Invalid figure', excludeEmptyString: true }),
 });
 
 const proteinSchema = Yup.object()

--- a/src/lib/constants/v2_form/validationSchema.js
+++ b/src/lib/constants/v2_form/validationSchema.js
@@ -256,21 +256,23 @@ const proteinSchema = Yup.object()
       .max(16, 'Must be 16 characters or less')
       .matches(/^[A-Za-z0-9_.]+$/, 'Must contain only letters or numbers')
       .required('Alias is required'),
-    // Optional (item 7): mutant / engineered proteins legitimately lack a
-    // UniProt or RefSeq ID. The pattern still applies when a value is given,
-    // but an empty field is allowed.
+    // RefSeq is optional: mutant / engineered proteins legitimately lack one.
+    // The pattern still applies when a value is given, but an empty field is allowed.
     accession: Yup.string()
       .matches(alphaNumericPattern, {
         message: 'Must contain only letters and underscores',
         excludeEmptyString: true,
       })
       .notRequired(),
+    // UniProt ID is required: the protein's sequence, structures, cross-references
+    // (KEGG/PDB) and operon are all derived from the UniProt call, so without it
+    // the protein would be essentially empty.
     uniProtID: Yup.string()
       .matches(alphaNumericPattern, {
         message: 'Must contain only letters, numbers, and underscores',
         excludeEmptyString: true,
       })
-      .notRequired(),
+      .required('UniProt ID is required'),
     family: Yup.string()
       .oneOf(familyValues, 'Invalid family')
       .required('Family is required'),

--- a/src/lib/constants/v2_form/validationSchema.js
+++ b/src/lib/constants/v2_form/validationSchema.js
@@ -18,6 +18,7 @@ const ligandMethods = [
   'Spectrophotometric competition',
   'Spectral shift',
   'DNA affinity chromatography',
+  'Autophosphorylation assay',
 ];
 
 const operatorMethods = [
@@ -49,7 +50,13 @@ const mechanismValues = [
   'Signal transduction',
 ];
 
-const familyValues = ['TetR', 'LysR', 'AraC', 'MarR', 'LacI', 'GntR', 'LuxR', 'IclR', 'Other'];
+const baseFamilyValues = ['TetR', 'LysR', 'AraC', 'MarR', 'LacI', 'GntR', 'LuxR', 'IclR', 'Other'];
+// OmpR and HisKA are structural families for the individual proteins that make
+// up a two-component system. A lone protein in one of these families is an
+// incomplete entry, so they're only valid when the sensor has 2+ proteins
+// (enforced by the `two-component-only-families` test below).
+const twoComponentFamilyValues = ['OmpR', 'HisKA'];
+const familyValues = [...baseFamilyValues, ...twoComponentFamilyValues];
 
 function conditionallyRequiredString(options) {
   const {
@@ -337,15 +344,36 @@ const sharedExperimentSchema = Yup.object().shape({
   // Placeholder
 });
 
-export const v2_validationSchema = Yup.object().shape({
-  sensor: sensorSchema,
-  shared: Yup.object().shape({
-    experiment: sharedExperimentSchema,
-  }),
-  proteins: Yup.array()
-    .of(proteinSchema)
-    .min(1, 'At least one protein is required')
-    .required('Proteins array is required'),
-});
+export const v2_validationSchema = Yup.object()
+  .shape({
+    sensor: sensorSchema,
+    shared: Yup.object().shape({
+      experiment: sharedExperimentSchema,
+    }),
+    proteins: Yup.array()
+      .of(proteinSchema)
+      .min(1, 'At least one protein is required')
+      .required('Proteins array is required'),
+  })
+  // OmpR/HisKA only make sense for a two-component system, so a single-protein
+  // submission can't use them. The error is attached to the offending protein's
+  // family field so it surfaces inline on the About tab.
+  .test(
+    'two-component-only-families',
+    'OmpR and HisKA are only valid for two-component systems',
+    function (value) {
+      const proteins = value?.proteins ?? [];
+      if (proteins.length >= 2) return true;
+      const offenderIndex = proteins.findIndex((p) =>
+        twoComponentFamilyValues.includes(p?.family)
+      );
+      if (offenderIndex === -1) return true;
+      return this.createError({
+        path: `proteins[${offenderIndex}].family`,
+        message:
+          'OmpR and HisKA are only valid for two-component systems — add a second protein',
+      });
+    }
+  );
 
 export default v2_validationSchema;

--- a/src/lib/constants/v2_form/validationSchema.js
+++ b/src/lib/constants/v2_form/validationSchema.js
@@ -249,15 +249,21 @@ const proteinSchema = Yup.object()
       .max(16, 'Must be 16 characters or less')
       .matches(/^[A-Za-z0-9_.]+$/, 'Must contain only letters or numbers')
       .required('Alias is required'),
+    // Optional (item 7): mutant / engineered proteins legitimately lack a
+    // UniProt or RefSeq ID. The pattern still applies when a value is given,
+    // but an empty field is allowed.
     accession: Yup.string()
-      .matches(alphaNumericPattern, 'Must contain only letters and underscores')
-      .required('Accession is required'),
+      .matches(alphaNumericPattern, {
+        message: 'Must contain only letters and underscores',
+        excludeEmptyString: true,
+      })
+      .notRequired(),
     uniProtID: Yup.string()
-      .matches(
-        alphaNumericPattern,
-        'Must contain only letters, numbers, and underscores'
-      )
-      .required('UniProtID is required'),
+      .matches(alphaNumericPattern, {
+        message: 'Must contain only letters, numbers, and underscores',
+        excludeEmptyString: true,
+      })
+      .notRequired(),
     family: Yup.string()
       .oneOf(familyValues, 'Invalid family')
       .required('Family is required'),

--- a/src/zustand/v2SensorTable.store.js
+++ b/src/zustand/v2SensorTable.store.js
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { produce } from 'immer';
 
-const FAMILY_KEYS = ['all', 'tetr', 'lysr', 'arac', 'marr', 'laci', 'gntr', 'luxr', 'iclr', 'other'];
+const FAMILY_KEYS = ['all', 'tetr', 'lysr', 'arac', 'marr', 'laci', 'gntr', 'luxr', 'iclr', 'other', 'dual'];
 
 const useV2SensorTableStore = create((set, get) => ({
   tables: Object.fromEntries(FAMILY_KEYS.map((k) => [k, null])), // null = not fetched


### PR DESCRIPTION
## Pull Request Summary

### Description

Adds admin tooling to manage the sensor lifecycle past submission, surfaces two-component ("Dual") systems in the UI, and brings the add-sensor form in line with the updated backend validation:

- **Admin processed sensors** can now be promoted to the live database or rejected, with per-row status handling and snackbar feedback.
- **New admin "Published Sensors" console** to search and delete live sensors, reading from the public R2 index (cache-busted so it reflects current production state).
- **Two-component systems** ("Dual" family) are now a first-class family bucket — family tiles, the sensor-table store, and the `D` grv_id prefix all route to the `dual` category, shown as "Two-Component".
- **`Signal transduction` mechanism** is auto-selected and locked for multi-component sensors (2+ proteins) in the add form.
- **Optional UniProt / RefSeq IDs**: the form no longer requires them (engineered/mutant proteins), and `ProteinPanel` degrades gracefully when they're absent (omits ID rows/links, AlphaFold, and the structure card).
- **Required light/temperature evidence**: DOI, figure type/number, and method are now required on those stimulus entries, matching ligand/operator requirements.
- Minor: operator DNA logo on the `OperatorViewer`, admin layout width, local-dev comments in `aws-exports.js`.

### Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🎨 UI/UX improvements

## Testing

### Test Coverage

- [x] End-to-end tests added/updated
- [x] Manual testing completed

Ran the Cypress **e2e** suite against the local dev server — **12/12 specs passing** (includes `adminPage`, `addNewSensor`, `familyPage`, `sensor`). No e2e specs were added; existing ones cover the touched pages.

> Note: the Cypress **component** suite could not be run — Cypress 14.5.3 dropped the `create-react-app` devServer preset, so the component runner crashes at config load. This is a pre-existing environment issue, unrelated to this branch.

### Browser Testing

- [x] Chrome (Cypress / Electron)

## Code Quality

### Development Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] New and existing e2e tests pass locally

### Performance Impact

- [x] No performance impact

### Security Considerations

- [x] Follows security best practices

Admin delete/promote/reject calls go through authenticated endpoints (`authHeaders`). The published-sensor list is read from the public, unauthenticated R2 index (same source as the public tables); only the mutating actions require auth.

## Data & Dependencies

### Dependency Changes

- [x] No new dependencies

## Deployment

### Environment Requirements

- [x] No special requirements

### Breaking Changes

Light and temperature stimulus entries now require DOI, figure type, figure number, and method; the form will block submission until they're filled. Existing in-progress drafts missing these fields will fail validation.

## Review Notes

### Areas of Focus

- `AdminPublishedSensorsV2.js` (new) and the new mutating endpoints in `lib/api/v2Admin.js` — confirm the endpoint contracts/status-code handling match the backend.
- "Dual"/Two-Component routing across `RegFamilyTiles`, `v2SensorTable.store`, and the `D` prefix in `SensorPageV2` — currently reuses the `Other` artwork.

### Known Issues

- The "Dual" family tile reuses `Other-family.png` (no dedicated artwork yet).

## Additional Context

Pairs with the backend changes in **groov-db-api#18** (optional UniProt/RefSeq, `Signal transduction` mechanism, required light/temp evidence). That PR is not yet merged, so the optional-ID and mechanism behavior depends on it shipping.
