### PR TITLE
Unstick end users browsers with the V2 migration with a temporary cache bust

### DIFF
--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -17,12 +17,12 @@ describe('Home page spec', () => {
       'Find your sensor'
     );
     cy.get('.Mui-selected').should('have.attr', 'tabindex', '0');
-    cy.get('[tabindex="-1"]').click();
+    cy.get('[tabindex="-1"]').click({force: true});
     cy.get('#ligand-search-input').should('be.visible');
     cy.get('#ligand-search-input-label').should('have.text', 'SMILES String');
-    cy.get('#use-example-smiles').click();
+    cy.get('#use-example-smiles').click({force: true});
     cy.get('#ligand-search-input').should('have.value', 'CC1=C(C(=CC(=C1)CCCC(C)C)O)C(C)');
-    cy.get('#search-button').click();
+    cy.get('#search-button').click({force: true});
     /* ==== End Cypress Studio ==== */
     /* ==== Generated with Cypress Studio ==== */
     cy.get('#results-total').should('have.text', "Results (6)");

--- a/src/Components/About/DownloadAllSensors.js
+++ b/src/Components/About/DownloadAllSensors.js
@@ -3,6 +3,7 @@ import { Button, CircularProgress } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import { useAllSensors } from '../../queries/sensors.js';
 import { useFeatureFlag } from '../../zustand/featureFlags.store';
+import { withCacheBust } from '../../lib/utils.js';
 
 export default function DownloadAllSensors() {
   const [isDownloading, setIsDownloading] = useState(false);
@@ -15,12 +16,12 @@ export default function DownloadAllSensors() {
       
       let dataToDownload;
       if (v2SensorTablesEnabled) {
-        const response = await fetch('https://groov-api.com/v2/all-sensors.json');
+        const response = await fetch(withCacheBust('https://groov-api.com/v2/all-sensors.json'));
         dataToDownload = await response.json();
       } else if (sensorsData.length > 0) {
         dataToDownload = { sensors: sensorsData };
       } else {
-        const response = await fetch('https://groov-api.com/all-sensors.json');
+        const response = await fetch(withCacheBust('https://groov-api.com/all-sensors.json'));
         dataToDownload = await response.json();
       }
 

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import useSearchStore from '../zustand/search.store.js';
+import { withCacheBust } from '../lib/utils.js';
 import useFeatureFlagsStore, {
   useFeatureFlag,
 } from '../zustand/featureFlags.store.js';
@@ -53,7 +54,7 @@ export default function Search() {
     if (labels.length > 0) return;
 
     if (v2Enabled) {
-      fetch('https://groov-api.com/v2/index.json', {
+      fetch(withCacheBust('https://groov-api.com/v2/index.json'), {
         headers: { Accept: 'application/json' },
       })
         .then((res) => res.json())
@@ -62,7 +63,7 @@ export default function Search() {
           setStats(indexData.stats);
         });
     } else {
-      fetch('https://groov-api.com/index.json', {
+      fetch(withCacheBust('https://groov-api.com/index.json'), {
         headers: { Accept: 'application/json' },
       })
         .then((res) => res.json())

--- a/src/Components/Sensor_Components/SensorTableV2.js
+++ b/src/Components/Sensor_Components/SensorTableV2.js
@@ -4,7 +4,7 @@ import { Box, Grid, Skeleton, Link as MuiLink } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 
 import useV2SensorTableStore from '../../zustand/v2SensorTable.store.js';
-import { getFirstTwoWords } from '../../lib/utils.js';
+import { getFirstTwoWords, withCacheBust } from '../../lib/utils.js';
 
 const UNIPROT_COLUMN = {
   field: 'uniprot_id',
@@ -51,7 +51,7 @@ export default function SensorTableV2({ family }) {
     const url = isAllSensors
       ? 'https://groov-api.com/v2/index.json'
       : `https://groov-api.com/v2/indexes/${family.toLowerCase()}.json`;
-    fetchTable(storeKey, url);
+    fetchTable(storeKey, withCacheBust(url));
   }, [storeKey, isAllSensors, fetchTable]);
 
   const rows = useMemo(() => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -12,4 +12,21 @@ function getFirstTwoWords(inputString) {
   return firstTwoWords.join(' ');
 }
 
-export { getFirstTwoWords };
+// TEMPORARY cache-buster for the public v2/*.json data files.
+//
+// Those files are served with no `Cache-Control` header, so browsers apply
+// heuristic caching (~10% of the file's age) and keep serving a stale copy
+// without revalidating. That's why a freshly published sensor can take hours
+// to show up in the /database table for returning users. Appending a unique
+// query param forces a fresh fetch every load, which un-sticks users who are
+// already holding a stale copy.
+//
+// This defeats CDN caching too (every URL is unique), so REMOVE this once the
+// real fix is live in Cloudflare: short Browser TTL + long Edge TTL + a cache
+// purge on data publish. See the Cloudflare setup notes in the PR.
+function withCacheBust(url) {
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}t=${Date.now()}`;
+}
+
+export { getFirstTwoWords, withCacheBust };


### PR DESCRIPTION
This PR will unstick anyone currently using groov that has their browser still serving the old index.json and other static files